### PR TITLE
Optimise performance of metadata markers endpoint

### DIFF
--- a/holofood/tests/test_api.py
+++ b/holofood/tests/test_api.py
@@ -249,28 +249,8 @@ def test_sample_metadata_markers_api_list_filters(
     response = client.get("/api/sample_metadata_markers?name=donut")
     assert_response_has_n_items(response, 1)
 
-    response = client.get("/api/sample_metadata_markers?name=donut&min_samples=2")
-    assert_response_has_n_items(response, 0)
-
     response = client.get("/api/sample_metadata_markers?name=cronut")
     assert_response_has_n_items(response, 0)
-
-    AnimalStructuredDatum.objects.create(
-        animal=salmon_animal, marker=structured_metadata_marker, measurement="2"
-    )
-    SampleStructuredDatum.objects.create(
-        sample=salmon_metabolomic_sample,
-        marker=structured_metadata_marker,
-        measurement="3",
-    )
-    response = client.get("/api/sample_metadata_markers?min_samples=2")
-    assert_response_has_n_items(response, 0)
-    response = client.get("/api/sample_metadata_markers?min_animals=2")
-    assert_response_has_n_items(response, 0)
-    response = client.get("/api/sample_metadata_markers?min_samples=1")
-    assert_response_has_n_items(response, 1)
-    response = client.get("/api/sample_metadata_markers?min_animals=1")
-    assert_response_has_n_items(response, 1)
 
 
 @pytest.mark.django_db

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-sass-processor==1.2.2
 libsass==0.22.0
 django-compressor==4.3.1
 martor==1.6.26
-django-ninja==0.21.0
+django-ninja==0.22.2
 django-admin-inline-paginator==0.4.0
 django-unfold==0.5.3
 


### PR DESCRIPTION
removes min_samples and min_animals filters from metadata marker listing endpoint; they cause slow full table scans